### PR TITLE
feat: improve upload zone samples and share/logs modals

### DIFF
--- a/packages/web/src/lib/components/LogsLocationModal.svelte
+++ b/packages/web/src/lib/components/LogsLocationModal.svelte
@@ -12,6 +12,8 @@ type OS = 'windows' | 'macos' | 'linux';
 let selectedAgent = $state<Agent>('claude');
 let selectedOS = $state<OS>(detectOS());
 let copied = $state(false);
+let copiedExport = $state(false);
+let copiedServe = $state(false);
 
 const agents: { id: Agent; name: string; label: string }[] = [
   { id: 'claude', name: 'Claude Code', label: 'claude' },
@@ -146,6 +148,21 @@ async function copyPath() {
   }
 }
 
+async function copyText(text: string, setter: (v: boolean) => void) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+  }
+  setter(true);
+  setTimeout(() => setter(false), 2000);
+}
+
 const currentPath = $derived(logPaths[selectedAgent][selectedOS]);
 const currentInstructions = $derived(instructions[selectedAgent]);
 const currentAgentName = $derived(
@@ -197,101 +214,214 @@ const currentAgentName = $derived(
       </div>
 
       <!-- Content -->
-      <div class="flex flex-1 overflow-hidden">
-        <!-- Left column: Agent selector -->
-        <div class="w-48 shrink-0 border-r border-edge p-4 space-y-2">
-          <p class="text-xs text-muted mb-3">// select agent</p>
-          {#each agents as agent}
-            <button
-              class="w-full text-left px-3 py-2 rounded text-sm transition-colors cursor-pointer {selectedAgent ===
+      <div class="flex-1 overflow-y-auto">
+        <div class="flex overflow-hidden">
+          <!-- Left column: Agent selector -->
+          <div class="w-48 shrink-0 border-r border-edge p-4 space-y-2">
+            <p class="text-xs text-muted mb-3">// select agent</p>
+            {#each agents as agent}
+              <button
+                class="w-full text-left px-3 py-2 rounded text-sm transition-colors cursor-pointer {selectedAgent ===
 							agent.id
 								? 'bg-accent-dim border border-accent text-accent'
 								: 'border border-edge text-foreground hover:border-foreground/30 hover:text-foreground-bright'}"
-              onclick={() => (selectedAgent = agent.id)}
-            >
-              <span class="text-muted text-xs">$</span>
-              {agent.label}
-            </button>
-          {/each}
-        </div>
-
-        <!-- Right column: OS selector and instructions -->
-        <div class="flex-1 p-5 overflow-y-auto">
-          <!-- OS selector -->
-          <div class="flex gap-1 mb-5 border-b border-edge">
-            {#each osOptions as os}
-              <button
-                class="px-4 py-2 text-sm transition-colors cursor-pointer -mb-px {selectedOS === os.id
-									? 'text-accent border-b-2 border-accent'
-									: 'text-muted hover:text-foreground-bright'}"
-                onclick={() => (selectedOS = os.id)}
+                onclick={() => (selectedAgent = agent.id)}
               >
-                {os.name}
+                <span class="text-muted text-xs">$</span>
+                {agent.label}
               </button>
             {/each}
           </div>
 
-          <!-- Instructions -->
-          <div class="space-y-4">
-            <div>
-              <h3 class="text-foreground-bright font-medium text-sm mb-2">
-                {currentAgentName}
-              </h3>
-              <p class="text-muted text-sm leading-relaxed">
-                {currentInstructions}
-              </p>
+          <!-- Right column: OS selector and instructions -->
+          <div class="flex-1 p-5 overflow-y-auto">
+            <!-- OS selector -->
+            <div class="flex gap-1 mb-5 border-b border-edge">
+              {#each osOptions as os}
+                <button
+                  class="px-4 py-2 text-sm transition-colors cursor-pointer -mb-px {selectedOS === os.id
+									? 'text-accent border-b-2 border-accent'
+									: 'text-muted hover:text-foreground-bright'}"
+                  onclick={() => (selectedOS = os.id)}
+                >
+                  {os.name}
+                </button>
+              {/each}
             </div>
 
-            <!-- Path display -->
-            <div class="space-y-2">
-              <p class="text-xs text-muted">// default path</p>
-              <div
-                class="flex items-center gap-2 bg-surface border border-edge rounded px-3 py-2 font-mono text-sm"
-              >
-                <code
-                  class="flex-1 text-foreground-bright overflow-x-auto whitespace-nowrap"
-                >
-                  {currentPath.path}
-                </code>
-                <button
-                  class="shrink-0 text-muted hover:text-accent transition-colors cursor-pointer p-1"
-                  onclick={copyPath}
-                  aria-label="Copy path"
-                  title="Copy path"
-                >
-                  {#if copied}
-                    <svg
-                      class="w-4 h-4 text-status-success"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M5 13l4 4L19 7"
-                      />
-                    </svg>
-                  {:else}
-                    <svg
-                      class="w-4 h-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                      />
-                    </svg>
-                  {/if}
-                </button>
+            <!-- Instructions -->
+            <div class="space-y-4">
+              <div>
+                <h3 class="text-foreground-bright font-medium text-sm mb-2">
+                  {currentAgentName}
+                </h3>
+                <p class="text-muted text-sm leading-relaxed">
+                  {currentInstructions}
+                </p>
               </div>
-              <p class="text-xs text-muted/60">{currentPath.expanded}</p>
+
+              <!-- Path display -->
+              <div class="space-y-2">
+                <p class="text-xs text-muted">// default path</p>
+                <div
+                  class="flex items-center gap-2 bg-surface border border-edge rounded px-3 py-2 font-mono text-sm"
+                >
+                  <code
+                    class="flex-1 text-foreground-bright overflow-x-auto whitespace-nowrap"
+                  >
+                    {currentPath.path}
+                  </code>
+                  <button
+                    class="shrink-0 text-muted hover:text-accent transition-colors cursor-pointer p-1"
+                    onclick={copyPath}
+                    aria-label="Copy path"
+                    title="Copy path"
+                  >
+                    {#if copied}
+                      <svg
+                        class="w-4 h-4 text-status-success"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    {:else}
+                      <svg
+                        class="w-4 h-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                        />
+                      </svg>
+                    {/if}
+                  </button>
+                </div>
+                <p class="text-xs text-muted/60">{currentPath.expanded}</p>
+              </div>
             </div>
+          </div>
+        </div>
+
+        <!-- CLI section -->
+        <div class="border-t border-edge px-5 py-4 space-y-3">
+          <div>
+            <p class="text-foreground-bright font-medium text-sm">
+              Or use the CLI
+            </p>
+            <p class="text-xs text-muted mt-0.5">
+              Works with all agents — auto-discovers your sessions
+            </p>
+          </div>
+          <div class="space-y-2">
+            <div
+              class="flex items-center gap-2 bg-surface border border-edge rounded px-3 py-2 font-mono text-sm"
+            >
+              <code
+                class="flex-1 text-foreground-bright overflow-x-auto whitespace-nowrap"
+              >
+                <span class="text-muted">$</span> npx @endorhq/capsule export
+              </code>
+              <button
+                class="shrink-0 text-muted hover:text-accent transition-colors cursor-pointer p-1"
+                onclick={() => copyText('npx @endorhq/capsule export', (v) => (copiedExport = v))}
+                aria-label="Copy export command"
+                title="Copy command"
+              >
+                {#if copiedExport}
+                  <svg
+                    class="w-4 h-4 text-status-success"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                {:else}
+                  <svg
+                    class="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                    />
+                  </svg>
+                {/if}
+              </button>
+            </div>
+            <p class="text-xs text-muted/60 pl-1">
+              Export a session file to upload here
+            </p>
+
+            <div
+              class="flex items-center gap-2 bg-surface border border-edge rounded px-3 py-2 font-mono text-sm"
+            >
+              <code
+                class="flex-1 text-foreground-bright overflow-x-auto whitespace-nowrap"
+              >
+                <span class="text-muted">$</span> npx @endorhq/capsule serve
+              </code>
+              <button
+                class="shrink-0 text-muted hover:text-accent transition-colors cursor-pointer p-1"
+                onclick={() => copyText('npx @endorhq/capsule serve', (v) => (copiedServe = v))}
+                aria-label="Copy serve command"
+                title="Copy command"
+              >
+                {#if copiedServe}
+                  <svg
+                    class="w-4 h-4 text-status-success"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                {:else}
+                  <svg
+                    class="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                    />
+                  </svg>
+                {/if}
+              </button>
+            </div>
+            <p class="text-xs text-muted/60 pl-1">
+              Start a local viewer with auto-discovery
+            </p>
           </div>
         </div>
       </div>

--- a/packages/web/src/lib/components/UploadZone.svelte
+++ b/packages/web/src/lib/components/UploadZone.svelte
@@ -200,29 +200,6 @@ function handleFileChange(e: Event) {
           <p class="text-xs text-status-error">{gistError}</p>
         {/if}
       </div>
-
-      <div class="flex items-center gap-3 w-full my-1">
-        <div class="flex-1 border-t border-edge"></div>
-        <span class="text-xs text-muted">or try a session sample</span>
-        <div class="flex-1 border-t border-edge"></div>
-      </div>
-
-      <div class="flex gap-2 w-full">
-        <button
-          onclick={() => loadSample('claude', 'claude-sample.jsonl')}
-          disabled={!!sampleLoading}
-          class="flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm border border-edge rounded hover:border-accent/50 hover:text-foreground-bright transition-colors cursor-pointer text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          Claude Code
-        </button>
-        <button
-          onclick={() => loadSample('codex', 'codex-sample.jsonl')}
-          disabled={!!sampleLoading}
-          class="flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm border border-edge rounded hover:border-accent/50 hover:text-foreground-bright transition-colors cursor-pointer text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          Codex
-        </button>
-      </div>
     {/if}
   </div>
   <button
@@ -231,6 +208,34 @@ function handleFileChange(e: Event) {
   >
     ? where can I find my session logs?
   </button>
+  {#if onGistLoad}
+    <div
+      class="max-w-lg w-full mt-12 rounded-lg border border-accent/20 bg-accent/[0.03] p-5"
+    >
+      <div class="text-center mb-3">
+        <h3 class="text-sm font-semibold text-accent">Just curious?</h3>
+        <p class="text-xs text-muted mt-0.5">
+          Try a sample file to see how it looks
+        </p>
+      </div>
+      <div class="flex gap-2 w-full">
+        <button
+          onclick={() => loadSample('claude', 'claude-sample.jsonl')}
+          disabled={!!sampleLoading}
+          class="flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm border border-accent/20 rounded hover:border-accent/50 hover:bg-accent/5 hover:text-foreground-bright transition-colors cursor-pointer text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Claude Code
+        </button>
+        <button
+          onclick={() => loadSample('codex', 'codex-sample.jsonl')}
+          disabled={!!sampleLoading}
+          class="flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm border border-accent/20 rounded hover:border-accent/50 hover:bg-accent/5 hover:text-foreground-bright transition-colors cursor-pointer text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Codex
+        </button>
+      </div>
+    </div>
+  {/if}
 </div>
 
 <LogsLocationModal

--- a/packages/web/src/lib/components/modals/ShareModal.svelte
+++ b/packages/web/src/lib/components/modals/ShareModal.svelte
@@ -10,6 +10,28 @@ interface Props {
 let { open, sessionMeta, onClose }: Props = $props();
 
 let copied = $state(false);
+let copiedCmd = $state(false);
+let manualExpanded = $state(false);
+let manualGistInput = $state('');
+let copiedManualLink = $state(false);
+
+function extractGistId(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  // Match gist.github.com URLs: gist.github.com/user/id or gist.github.com/id
+  const urlMatch = trimmed.match(/gist\.github\.com\/(?:[^/]+\/)?([a-f0-9]+)/i);
+  if (urlMatch) return urlMatch[1];
+  // Match raw hex gist ID
+  if (/^[a-f0-9]+$/i.test(trimmed)) return trimmed;
+  return null;
+}
+
+const manualGistId = $derived(extractGistId(manualGistInput));
+const manualShareUrl = $derived.by(() => {
+  if (!manualGistId) return '';
+  if (typeof window === 'undefined') return '';
+  return `${window.location.origin}?gist=${manualGistId}`;
+});
 
 const isGist = $derived(sessionMeta.source?.type === 'gist');
 const gistId = $derived(
@@ -32,6 +54,21 @@ function handleKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
     onClose();
   }
+}
+
+async function copyText(text: string, setter: (v: boolean) => void) {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+  }
+  setter(true);
+  setTimeout(() => setter(false), 2000);
 }
 
 async function copyUrl() {
@@ -172,41 +209,202 @@ async function copyUrl() {
         {:else}
           <div class="space-y-4">
             <p class="text-muted text-sm">
-              This session is stored locally and cannot be shared directly.
+              This session is stored locally and cannot be shared directly. Use
+              the CLI to publish it as a GitHub Gist with a single command.
             </p>
 
-            <div class="bg-surface border border-edge rounded p-4 space-y-3">
-              <p class="text-foreground-bright text-sm font-medium">
-                // to share this session:
+            <div class="space-y-2">
+              <p class="text-xs text-muted">// publish to gist</p>
+              <div
+                class="flex items-center gap-2 bg-surface border border-edge rounded px-3 py-2 font-mono text-sm"
+              >
+                <code
+                  class="flex-1 text-foreground-bright overflow-x-auto whitespace-nowrap"
+                >
+                  <span class="text-muted">$</span> npx @endorhq/capsule share
+                </code>
+                <button
+                  class="shrink-0 text-muted hover:text-accent transition-colors cursor-pointer p-1"
+                  onclick={() => copyText('npx @endorhq/capsule share', (v) => (copiedCmd = v))}
+                  aria-label="Copy command"
+                  title="Copy command"
+                >
+                  {#if copiedCmd}
+                    <svg
+                      class="w-4 h-4 text-status-success"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  {:else}
+                    <svg
+                      class="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                      />
+                    </svg>
+                  {/if}
+                </button>
+              </div>
+              <p class="text-xs text-muted/60 pl-1">
+                Interactively select a session, anonymize sensitive data, and
+                publish to GitHub Gist
               </p>
-              <ol class="text-muted text-sm space-y-2 list-decimal list-inside">
-                <li>Export the session file</li>
-                <li>Create a GitHub Gist with the file</li>
-                <li>Share the gist URL</li>
-              </ol>
             </div>
 
-            <a
-              href="https://gist.github.com/new"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-2 text-accent hover:text-accent/80 text-sm transition-colors"
+            <div
+              class="flex items-start gap-2 bg-accent/[0.04] border border-accent/15 rounded px-3 py-2.5"
             >
               <svg
-                class="w-4 h-4"
+                class="w-4 h-4 text-accent shrink-0 mt-0.5"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
-                stroke-width="2"
+                stroke-width="1.5"
               >
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
-                  d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+                  d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
                 />
               </svg>
-              create a new gist on github
-            </a>
+              <p class="text-xs text-muted leading-relaxed">
+                Includes built-in
+                <span class="text-accent">anonymization tools</span> to strip
+                file paths, environment variables, and other sensitive data
+                before sharing.
+              </p>
+            </div>
+            <!-- Manual sharing expandable -->
+            <div class="border border-edge rounded overflow-hidden">
+              <button
+                class="w-full flex items-center justify-between px-3 py-2.5 text-sm text-muted hover:text-foreground-bright transition-colors cursor-pointer"
+                onclick={() => (manualExpanded = !manualExpanded)}
+              >
+                <span>Sharing it manually</span>
+                <svg
+                  class="w-4 h-4 transition-transform {manualExpanded ? 'rotate-180' : ''}"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="m19.5 8.25-7.5 7.5-7.5-7.5"
+                  />
+                </svg>
+              </button>
+              {#if manualExpanded}
+                <div class="px-3 pb-3 space-y-4 border-t border-edge pt-3">
+                  <ol
+                    class="text-muted text-sm space-y-2 list-decimal list-inside"
+                  >
+                    <li>Export the session file</li>
+                    <li>Create a GitHub Gist with the file</li>
+                    <li>Paste the gist URL below to get your share link</li>
+                  </ol>
+
+                  <a
+                    href="https://gist.github.com/new"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-2 text-accent hover:text-accent/80 text-sm transition-colors"
+                  >
+                    <svg
+                      class="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+                      />
+                    </svg>
+                    create a new gist on github
+                  </a>
+
+                  <div class="space-y-2">
+                    <p class="text-xs text-muted">// paste your gist URL</p>
+                    <input
+                      type="text"
+                      bind:value={manualGistInput}
+                      placeholder="gist.github.com/user/id or gist ID"
+                      class="w-full px-3 py-2 text-sm bg-surface border border-edge rounded text-foreground placeholder:text-muted/50 focus:outline-none focus:border-accent"
+                    />
+                  </div>
+
+                  {#if manualShareUrl}
+                    <div class="space-y-1.5">
+                      <p class="text-xs text-muted">// your share link</p>
+                      <div
+                        class="flex items-center gap-2 bg-surface border border-accent/30 rounded px-3 py-2 font-mono text-sm"
+                      >
+                        <code
+                          class="flex-1 text-accent overflow-x-auto whitespace-nowrap"
+                        >
+                          {manualShareUrl}
+                        </code>
+                        <button
+                          class="shrink-0 text-muted hover:text-accent transition-colors cursor-pointer p-1"
+                          onclick={() => copyText(manualShareUrl, (v) => (copiedManualLink = v))}
+                          aria-label="Copy share link"
+                          title="Copy share link"
+                        >
+                          {#if copiedManualLink}
+                            <svg
+                              class="w-4 h-4 text-status-success"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              stroke-width="2"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                d="M5 13l4 4L19 7"
+                              />
+                            </svg>
+                          {:else}
+                            <svg
+                              class="w-4 h-4"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                              stroke-width="2"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                              />
+                            </svg>
+                          {/if}
+                        </button>
+                      </div>
+                    </div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
           </div>
         {/if}
       </div>

--- a/packages/web/src/lib/components/viewer/panel/SessionActions.svelte
+++ b/packages/web/src/lib/components/viewer/panel/SessionActions.svelte
@@ -12,7 +12,7 @@ let { meta, onDelete, onShare }: Props = $props();
 
 <div class="flex gap-2">
   <button
-    class="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs text-muted border border-edge rounded hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
+    class="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs text-red-400/60 border border-red-400/20 rounded hover:text-red-400 hover:border-red-400/50 transition-colors cursor-pointer"
     onclick={onDelete}
     title="Delete session"
   >
@@ -32,7 +32,7 @@ let { meta, onDelete, onShare }: Props = $props();
     delete
   </button>
   <button
-    class="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs text-muted border border-edge rounded hover:text-accent hover:border-accent/50 transition-colors cursor-pointer"
+    class="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-xs text-accent/60 border border-accent/20 rounded hover:text-accent hover:border-accent/50 transition-colors cursor-pointer"
     onclick={onShare}
     title="Share session"
   >


### PR DESCRIPTION
## Summary
- Move sample session buttons out of the upload dashed box into a separate highlighted "Just curious?" section below
- Add CLI commands (`npx @endorhq/capsule export`, `serve`, `share`) with copy buttons to the "Where can I find my logs?" modal
- Revamp the share modal for local sessions: show the CLI `share` command with anonymization callout, and add an expandable "Sharing it manually" section with gist URL input to generate share links
- Give the delete and share action buttons a subtle color tint so they're more visible

## Test plan
- [x] Verify the upload zone shows samples in a separate teal-bordered box below the upload area
- [x] Open the "Where can I find my session logs?" modal and confirm the CLI section appears at the bottom with working copy buttons
- [x] Open the share modal for a local session and verify the CLI command, anonymization callout, and expandable manual section all render correctly
- [x] In the manual section, paste a gist URL and confirm the share link is generated and copyable
- [x] Verify delete/share buttons in the session panel have visible tinted colors