### PR TITLE
Fix double border in TabBar component

### DIFF
--- a/packages/web/src/lib/components/viewer/TabBar.svelte
+++ b/packages/web/src/lib/components/viewer/TabBar.svelte
@@ -36,5 +36,5 @@ const canClose = $derived(tabs.length > 1 || tabs[0]?.sessionId !== null);
     +
   </button>
 
-  <div class="flex-1 border-b border-edge"></div>
+  <div class="flex-1"></div>
 </div>


### PR DESCRIPTION
## Summary

- Fixes the duplicate bottom border on the TabBar fill div that caused a visible 2px border instead of 1px across the entire tab row

Closes #8